### PR TITLE
fix: take address of optional value via named variable to avoid rvalue address error

### DIFF
--- a/src/processingbase/ProcessingManager.cpp
+++ b/src/processingbase/ProcessingManager.cpp
@@ -666,7 +666,8 @@ namespace sgns::sgprocessing
         {
             return outcome::failure( Error::NO_PROCESSOR );
         }
-        const auto *parameters = processing_.get_parameters() ? &processing_.get_parameters().value() : nullptr;
+        auto parametersOpt = processing_.get_parameters();
+        const auto *parameters = parametersOpt ? &parametersOpt.value() : nullptr;
         auto processResult = m_processor->StartProcessing( chunkhashes,
                                    processing_.get_inputs()[index.value()],
                                    *buffers->second,


### PR DESCRIPTION
## Problem

In ProcessingManager::Process(), get_parameters() returns a boost::optional by value. The existing code dereferenced the optional inline and took the address of the resulting temporary value, which leads to undefined behaviour due to a dangling pointer.

Newer Clang versions (15+) correctly reject this as a hard compiler error.

## Fix

Store the optional result in a named local variable before accessing .value(). This ensures the optional remains alive for the duration of the processing call and the pointer remains valid.

## Verification

* Reproduced locally on macOS with Clang 15+
* Verified successful build after applying the fix
* Confirmed no functional behaviour changes
