### PR TITLE
feat: Add MNN_LLM and FP4_ULTRA processors

### DIFF
--- a/generated/DataType.hpp
+++ b/generated/DataType.hpp
@@ -16,5 +16,5 @@
 namespace sgns {
     using nlohmann::json;
 
-    enum class DataType : int { BOOL, BUFFER, FLOAT, INT, MAT2, MAT3, MAT4, STRING, TENSOR, TEXTURE1_D, TEXTURE2_D, TEXTURE3_D, TEXTURE_CUBE, VEC2, VEC3, VEC4 };
+    enum class DataType : int { BOOL, BUFFER, FLOAT, FP4_ULTRA, INT, LLM, MAT2, MAT3, MAT4, STRING, TENSOR, TEXTURE1_D, TEXTURE2_D, TEXTURE3_D, TEXTURE_CUBE, VEC2, VEC3, VEC4 };
 }

--- a/generated/Generators.hpp
+++ b/generated/Generators.hpp
@@ -414,7 +414,9 @@ namespace sgns {
             {"bool", DataType::BOOL},
             {"buffer", DataType::BUFFER},
             {"float", DataType::FLOAT},
+            {"fp4_ultra", DataType::FP4_ULTRA},
             {"int", DataType::INT},
+            {"llm", DataType::LLM},
             {"mat2", DataType::MAT2},
             {"mat3", DataType::MAT3},
             {"mat4", DataType::MAT4},
@@ -439,7 +441,9 @@ namespace sgns {
             case DataType::BOOL: j = "bool"; break;
             case DataType::BUFFER: j = "buffer"; break;
             case DataType::FLOAT: j = "float"; break;
+            case DataType::FP4_ULTRA: j = "fp4_ultra"; break;
             case DataType::INT: j = "int"; break;
+            case DataType::LLM: j = "llm"; break;
             case DataType::MAT2: j = "mat2"; break;
             case DataType::MAT3: j = "mat3"; break;
             case DataType::MAT4: j = "mat4"; break;

--- a/gnus-processing-schema.json
+++ b/gnus-processing-schema.json
@@ -454,7 +454,7 @@
       "enum": [
         "texture1D", "texture2D", "texture3D", "textureCube",
         "tensor", "float", "int", "bool", "vec2", "vec3", "vec4",
-        "mat2", "mat3", "mat4", "buffer", "string"
+        "mat2", "mat3", "mat4", "buffer", "string", "llm", "fp4_ultra"
       ]
     }
   }

--- a/include/processingbase/ProcessingManager.hpp
+++ b/include/processingbase/ProcessingManager.hpp
@@ -19,7 +19,9 @@
 #include <processors/processing_processor_mnn_bool.hpp>
 #include <processors/processing_processor_mnn_buffer.hpp>
 #include <processors/processing_processor_mnn_float.hpp>
+#include <processors/processing_processor_mnn_fp4ultra.hpp>
 #include <processors/processing_processor_mnn_int.hpp>
+#include <processors/processing_processor_mnn_llm.hpp>
 #include <boost/asio/io_context.hpp>
 #include <iostream>
 

--- a/include/processors/processing_processor_mnn_fp4ultra.hpp
+++ b/include/processors/processing_processor_mnn_fp4ultra.hpp
@@ -1,0 +1,47 @@
+/**
+ * MNN processor for FP4_ULTRA quantized input data
+ *
+ * Handles input data in FP4_ULTRA format (4-bit NF4-style quantization).
+ * The processor dequantizes packed nibbles + per-macroblock scales to FLOAT32,
+ * then runs standard windowed MNN inference (same pattern as MNN_Float).
+ *
+ * FP4_ULTRA data layout:
+ *   [packed_nibbles: (num_elements+1)/2 bytes] [scales: num_macroblocks * 4 bytes]
+ *
+ * Each macroblock is 64x64 = 4096 elements with one float32 scale factor.
+ * Nibbles index into a 16-entry NF4 lookup table in [-1, 1].
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <MNN/Interpreter.hpp>
+#include "processing_processor.hpp"
+
+namespace sgns::sgprocessing
+{
+    class MNN_FP4Ultra : public ProcessingProcessor
+    {
+    public:
+        MNN_FP4Ultra() = default;
+        ~MNN_FP4Ultra() override = default;
+
+        ProcessingResult StartProcessing(
+            std::vector<std::vector<uint8_t>>  &chunkhashes,
+            const sgns::IoDeclaration          &proc,
+            std::vector<char>                  &fp4Data,
+            std::vector<char>                  &modelFile,
+            const std::vector<sgns::Parameter> *parameters ) override;
+
+    private:
+        /// Dequantize FP4 packed nibbles + scales to FLOAT32
+        std::vector<float> DequantizeFP4( const std::vector<char> &packed,
+                                           size_t                   num_elements );
+
+        /// Run single-pass MNN inference on float data
+        std::unique_ptr<MNN::Tensor> Process( const std::vector<float> &floatData,
+                                               std::vector<uint8_t>    &modelFileBytes,
+                                               int                      length );
+    };
+}

--- a/include/processors/processing_processor_mnn_llm.hpp
+++ b/include/processors/processing_processor_mnn_llm.hpp
@@ -1,0 +1,49 @@
+/**
+ * MNN LLM processor for autoregressive text generation
+ *
+ * Unlike single-pass processors (MNN_Float, MNN_String, etc.), this processor
+ * runs an autoregressive generation loop: tokenize → forward → sample → repeat.
+ * Input data is space-separated token IDs. Output is generated token IDs as int32 bytes.
+ *
+ * Generation parameters are read from the JSON "parameters" array:
+ *   - maxTokens (int, default 512)
+ *   - temperature (float, default 0.7)
+ *   - topP (float, default 0.9)
+ *   - topK (int, default 40)
+ *   - eosTokenId (int, default 2)
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <MNN/Interpreter.hpp>
+#include "processing_processor.hpp"
+
+namespace sgns::sgprocessing
+{
+    class MNN_LLM : public ProcessingProcessor
+    {
+    public:
+        MNN_LLM() = default;
+        ~MNN_LLM() override = default;
+
+        ProcessingResult StartProcessing(
+            std::vector<std::vector<uint8_t>>  &chunkhashes,
+            const sgns::IoDeclaration          &proc,
+            std::vector<char>                  &inputData,
+            std::vector<char>                  &modelFile,
+            const std::vector<sgns::Parameter> *parameters ) override;
+
+    private:
+        /// Run a single forward pass, return output tensor (logits)
+        std::unique_ptr<MNN::Tensor> Forward(
+            const std::vector<int32_t> &input_ids,
+            std::vector<uint8_t>       &modelFileBytes,
+            int                         seq_len );
+
+        /// Sample next token from logits using temperature + top-k + top-p
+        int32_t SampleToken( const float *logits, int vocab_size,
+                             float temperature, float top_p, int top_k ) const;
+    };
+}

--- a/src/processingbase/ProcessingManager.cpp
+++ b/src/processingbase/ProcessingManager.cpp
@@ -75,7 +75,9 @@ namespace sgns::sgprocessing
         RegisterProcessorFactory( static_cast<int>(DataType::BOOL), [] { return std::make_unique<sgprocessing::MNN_Bool>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::BUFFER), [] { return std::make_unique<sgprocessing::MNN_Buffer>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::FLOAT), [] { return std::make_unique<sgprocessing::MNN_Float>(); } );
+        RegisterProcessorFactory( static_cast<int>(DataType::FP4_ULTRA), [] { return std::make_unique<sgprocessing::MNN_FP4Ultra>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::INT), [] { return std::make_unique<sgprocessing::MNN_Int>(); } );
+        RegisterProcessorFactory( static_cast<int>(DataType::LLM), [] { return std::make_unique<sgprocessing::MNN_LLM>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::MAT2), [] { return std::make_unique<sgprocessing::MNN_Mat2>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::MAT3), [] { return std::make_unique<sgprocessing::MNN_Mat3>(); } );
         RegisterProcessorFactory( static_cast<int>(DataType::MAT4), [] { return std::make_unique<sgprocessing::MNN_Mat4>(); } );
@@ -375,10 +377,10 @@ namespace sgns::sgprocessing
                         const auto format = input.get_format().value();
                         if ( format != sgns::InputFormat::FLOAT32 && format != sgns::InputFormat::FLOAT16 &&
                              format != sgns::InputFormat::INT32 && format != sgns::InputFormat::INT16 &&
-                             format != sgns::InputFormat::INT8 
-                             /*&& format != sgns::InputFormat::FP4_ULTRA*/ )
+                             format != sgns::InputFormat::INT8 &&
+                             format != sgns::InputFormat::FP4_ULTRA )
                         {
-                            m_logger->error( "Tensor type supports FLOAT32/FLOAT16/INT32/INT16/INT8 only" );
+                            m_logger->error( "Tensor type supports FLOAT32/FLOAT16/INT32/INT16/INT8/FP4_ULTRA only" );
                             return outcome::failure( Error::PROCESS_INFO_MISSING );
                         }
                     }
@@ -539,6 +541,34 @@ namespace sgns::sgprocessing
                     else
                     {
                         m_logger->warn( "TextureCube input missing format; defaulting to RGB8" );
+                    }
+                    break;
+                }
+                case DataType::FP4_ULTRA:
+                {
+                    if ( !input.get_dimensions() || !input.get_dimensions()->get_width() )
+                    {
+                        m_logger->error( "FP4_ULTRA type missing width" );
+                        return outcome::failure( Error::PROCESS_INFO_MISSING );
+                    }
+
+                    if ( input.get_format() )
+                    {
+                        const auto format = input.get_format().value();
+                        if ( format != sgns::InputFormat::FP4_ULTRA )
+                        {
+                            m_logger->error( "FP4_ULTRA data type requires FP4_ULTRA format" );
+                            return outcome::failure( Error::PROCESS_INFO_MISSING );
+                        }
+                    }
+                    break;
+                }
+                case DataType::LLM:
+                {
+                    // LLM processor requires parameters for generation config
+                    if ( !processing_.get_parameters() )
+                    {
+                        m_logger->warn( "LLM input missing parameters; using defaults (maxTokens=512, temperature=0.7)" );
                     }
                     break;
                 }

--- a/src/processors/CMakeLists.txt
+++ b/src/processors/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library(SGProcessors STATIC
 	processing_processor_mnn_bool.cpp
 	processing_processor_mnn_buffer.cpp
 	processing_processor_mnn_float.cpp
+	processing_processor_mnn_fp4ultra.cpp
 	processing_processor_mnn_int.cpp
+	processing_processor_mnn_llm.cpp
 	processing_processor_mnn_mat2.cpp
 	processing_processor_mnn_mat3.cpp
 	processing_processor_mnn_mat4.cpp
@@ -19,7 +21,9 @@ add_library(SGProcessors STATIC
 	processing_processor_mnn_volume.cpp
 	../../include/processors/processing_processor.hpp
 	../../include/processors/processing_processor_mnn_audio.hpp
+	../../include/processors/processing_processor_mnn_fp4ultra.hpp
 	../../include/processors/processing_processor_mnn_image.hpp
+	../../include/processors/processing_processor_mnn_llm.hpp
 	../../include/processors/processing_processor_mnn_ml.hpp
 	../../include/processors/processing_processor_mnn_string.hpp
 	../../include/processors/processing_processor_mnn_bool.hpp

--- a/src/processors/processing_processor_mnn_fp4ultra.cpp
+++ b/src/processors/processing_processor_mnn_fp4ultra.cpp
@@ -1,0 +1,269 @@
+/**
+ * MNN processor for FP4_ULTRA quantized input data
+ *
+ * Workflow:
+ *   1. Dequantize FP4_ULTRA packed data → FLOAT32
+ *   2. Run windowed MNN inference (same pattern as MNN_Float)
+ *   3. Stitch overlapping windows, hash each chunk for proof-of-work
+ *
+ * FP4_ULTRA data layout in the input buffer:
+ *   [packed_nibbles: ceil(num_elements/2) bytes] [scales: num_macroblocks * sizeof(float)]
+ *
+ * Each macroblock covers 4096 elements (64×64) with one scale factor.
+ * Nibble values index into a 16-entry NF4 symmetric lookup table.
+ */
+
+#include "processors/processing_processor_mnn_fp4ultra.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <openssl/sha.h>
+#include "util/sha256.hpp"
+
+namespace sgns::sgprocessing
+{
+    using namespace MNN;
+
+    namespace
+    {
+        /// Macroblock size: 64 rows × 64 cols = 4096 elements
+        static constexpr size_t kMacroblockSize = 64 * 64;
+
+        /// NF4-style symmetric lookup table: 16 representable values in [-1, 1]
+        static constexpr float kFP4LUT[16] = {
+            -1.0f,    -0.6962f, -0.5251f, -0.3949f,
+            -0.2844f, -0.1848f, -0.0911f,  0.0f,
+             0.0796f,  0.1609f,  0.2461f,  0.3379f,
+             0.4407f,  0.5626f,  0.7230f,  1.0f
+        };
+
+        std::vector<int> ComputeWindowStarts( int length, int roi, int stride )
+        {
+            std::vector<int> starts;
+            if ( length <= roi )
+            {
+                starts.push_back( 0 );
+                return starts;
+            }
+
+            const int step = std::max( 1, stride );
+            for ( int pos = 0; pos <= length - roi; pos += step )
+                starts.push_back( pos );
+
+            const int last = length - roi;
+            if ( starts.empty() || starts.back() != last )
+                starts.push_back( last );
+
+            return starts;
+        }
+    }
+
+    std::vector<float> MNN_FP4Ultra::DequantizeFP4( const std::vector<char> &packed,
+                                                     size_t                   num_elements )
+    {
+        // Layout: [packed_nibbles | scales_as_float32]
+        const size_t packed_bytes    = ( num_elements + 1 ) / 2;
+        const size_t num_macroblocks = ( num_elements + kMacroblockSize - 1 ) / kMacroblockSize;
+        const size_t scales_bytes    = num_macroblocks * sizeof( float );
+
+        if ( packed.size() < packed_bytes + scales_bytes )
+        {
+            m_logger->error( "FP4_ULTRA data too small: {} bytes, need at least {} + {} = {}",
+                             packed.size(), packed_bytes, scales_bytes, packed_bytes + scales_bytes );
+            return {};
+        }
+
+        // Read per-macroblock scales from after the packed nibbles
+        std::vector<float> scales( num_macroblocks );
+        std::memcpy( scales.data(), packed.data() + packed_bytes, scales_bytes );
+
+        // Dequantize each element
+        std::vector<float> output( num_elements );
+        for ( size_t i = 0; i < num_elements; ++i )
+        {
+            const size_t byte_idx = i / 2;
+            uint8_t nibble;
+            if ( i % 2 == 0 )
+                nibble = ( static_cast<uint8_t>( packed[byte_idx] ) >> 4 ) & 0x0F;
+            else
+                nibble = static_cast<uint8_t>( packed[byte_idx] ) & 0x0F;
+
+            const size_t mb_idx = i / kMacroblockSize;
+            const float  scale  = ( mb_idx < scales.size() ) ? scales[mb_idx] : 1.0f;
+            output[i] = kFP4LUT[nibble] * scale;
+        }
+
+        m_logger->info( "FP4_ULTRA dequantized {} elements from {} macroblocks",
+                        num_elements, num_macroblocks );
+        return output;
+    }
+
+    ProcessingResult MNN_FP4Ultra::StartProcessing(
+        std::vector<std::vector<uint8_t>>  &chunkhashes,
+        const sgns::IoDeclaration          &proc,
+        std::vector<char>                  &fp4Data,
+        std::vector<char>                  &modelFile,
+        const std::vector<sgns::Parameter> *parameters )
+    {
+        (void)parameters;
+        std::vector<uint8_t> modelBytes( modelFile.begin(), modelFile.end() );
+
+        if ( !proc.get_dimensions() || !proc.get_dimensions()->get_width() )
+        {
+            m_logger->error( "FP4_ULTRA input missing width dimension" );
+            return ProcessingResult{};
+        }
+
+        const int length      = static_cast<int>( proc.get_dimensions()->get_width().value() );
+        const int patchLength = static_cast<int>(
+            proc.get_dimensions()->get_block_len().value_or( length ) );
+        const int stride = static_cast<int>(
+            proc.get_dimensions()->get_chunk_stride().value_or( patchLength ) );
+
+        if ( length <= 0 || patchLength <= 0 || stride <= 0 )
+        {
+            m_logger->error( "FP4_ULTRA: invalid length/patch/stride values" );
+            return ProcessingResult{};
+        }
+
+        // Dequantize FP4 → FLOAT32
+        std::vector<float> floatValues = DequantizeFP4( fp4Data, static_cast<size_t>( length ) );
+        if ( floatValues.empty() )
+        {
+            m_logger->error( "FP4_ULTRA: dequantization failed" );
+            return ProcessingResult{};
+        }
+
+        m_logger->info( "FP4_ULTRA processing: length={} patch={} stride={}", length, patchLength, stride );
+
+        // -----------------------------------------------------------------
+        // Windowed inference (same pattern as MNN_Float)
+        // -----------------------------------------------------------------
+        std::vector<uint8_t> subTaskResultHash( SHA256_DIGEST_LENGTH, 0 );
+        const auto starts = ComputeWindowStarts( length, patchLength, stride );
+
+        std::vector<float> stitchedOutput( length, 0.0f );
+        std::vector<float> stitchedWeights( length, 0.0f );
+
+        for ( int start : starts )
+        {
+            std::vector<float> patch( static_cast<size_t>( patchLength ), 0.0f );
+            for ( int i = 0; i < patchLength; ++i )
+            {
+                const int srcIndex = start + i;
+                if ( srcIndex >= length ) break;
+                patch[static_cast<size_t>( i )] = floatValues[static_cast<size_t>( srcIndex )];
+            }
+
+            auto procresults = Process( patch, modelBytes, patchLength );
+            if ( !procresults )
+            {
+                m_logger->error( "FP4_ULTRA: MNN inference failed for window at {}", start );
+                continue;
+            }
+
+            const float *data     = procresults->host<float>();
+            size_t       dataSize = procresults->elementSize() * sizeof( float );
+
+            // Stitch output (overlap-add)
+            const int outputLength = std::min( patchLength,
+                                               static_cast<int>( procresults->elementSize() ) );
+            for ( int i = 0; i < outputLength; ++i )
+            {
+                const int outIndex = start + i;
+                if ( outIndex >= length ) break;
+                stitchedOutput[outIndex]  += data[i];
+                stitchedWeights[outIndex] += 1.0f;
+            }
+
+            // Hash this chunk
+            auto hash = sgprocmanagersha::sha256( data, dataSize );
+            chunkhashes.push_back( hash );
+        }
+
+        // Normalize overlapping regions
+        for ( int i = 0; i < length; ++i )
+        {
+            if ( stitchedWeights[i] > 0.0f )
+                stitchedOutput[i] /= stitchedWeights[i];
+        }
+
+        // Final hash
+        std::string stitchedStr( reinterpret_cast<const char *>( stitchedOutput.data() ),
+                                  stitchedOutput.size() * sizeof( float ) );
+        subTaskResultHash = sgprocmanagersha::sha256( stitchedStr.c_str(), stitchedStr.size() );
+
+        m_progress = 100.0f;
+        m_logger->info( "FP4_ULTRA processing complete" );
+
+        // Build result
+        ProcessingResult result;
+        result.hash = subTaskResultHash;
+
+        if ( !stitchedOutput.empty() )
+        {
+            const size_t byteCount = stitchedOutput.size() * sizeof( float );
+            std::vector<char> outputBytes( byteCount );
+            std::memcpy( outputBytes.data(), stitchedOutput.data(), byteCount );
+
+            result.output_buffers =
+                std::make_shared<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>>();
+            result.output_buffers->first.push_back( "" );
+            result.output_buffers->second.push_back( std::move( outputBytes ) );
+        }
+
+        return result;
+    }
+
+    std::unique_ptr<MNN::Tensor> MNN_FP4Ultra::Process(
+        const std::vector<float> &floatData,
+        std::vector<uint8_t>     &modelFileBytes,
+        int                       length )
+    {
+        auto interpreter = std::unique_ptr<MNN::Interpreter>(
+            MNN::Interpreter::createFromBuffer( modelFileBytes.data(), modelFileBytes.size() ) );
+        if ( !interpreter )
+        {
+            m_logger->error( "FP4_ULTRA: Failed to create MNN interpreter" );
+            return nullptr;
+        }
+
+        MNN::ScheduleConfig config;
+        config.type      = MNN_FORWARD_VULKAN;
+        config.numThread = 4;
+        config.backendConfig = nullptr;
+
+        auto session = interpreter->createSession( config );
+        if ( !session )
+        {
+            m_logger->error( "FP4_ULTRA: Failed to create MNN session" );
+            return nullptr;
+        }
+
+        auto inputTensor = interpreter->getSessionInput( session, nullptr );
+        if ( !inputTensor )
+        {
+            m_logger->error( "FP4_ULTRA: Failed to get input tensor" );
+            return nullptr;
+        }
+
+        MNN::Tensor inputTensorUser( inputTensor, inputTensor->getDimensionType() );
+        auto inputPtr = inputTensorUser.host<float>();
+        std::memcpy( inputPtr, floatData.data(), static_cast<size_t>( length ) * sizeof( float ) );
+        inputTensor->copyFromHostTensor( &inputTensorUser );
+
+        interpreter->runSession( session );
+
+        auto outputTensor = interpreter->getSessionOutput( session, nullptr );
+        if ( !outputTensor )
+        {
+            m_logger->error( "FP4_ULTRA: Failed to get output tensor" );
+            return nullptr;
+        }
+
+        auto outputUserTensor = std::make_unique<MNN::Tensor>( outputTensor, outputTensor->getDimensionType() );
+        outputTensor->copyToHostTensor( outputUserTensor.get() );
+        return outputUserTensor;
+    }
+}

--- a/src/processors/processing_processor_mnn_llm.cpp
+++ b/src/processors/processing_processor_mnn_llm.cpp
@@ -1,0 +1,286 @@
+/**
+ * MNN LLM processor — autoregressive text generation
+ *
+ * This processor implements token-by-token generation:
+ *   1. Parse input as space-separated token IDs
+ *   2. Forward pass through MNN model → logits
+ *   3. Sample next token (temperature + top-k + top-p)
+ *   4. Append token, repeat until EOS or max_tokens
+ *   5. Output generated token IDs as raw int32 bytes
+ *   6. Chain SHA256 hashes per step for proof-of-work
+ */
+
+#include "processors/processing_processor_mnn_llm.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <openssl/sha.h>
+#include "util/sha256.hpp"
+
+namespace sgns::sgprocessing
+{
+    using namespace MNN;
+
+    ProcessingResult MNN_LLM::StartProcessing(
+        std::vector<std::vector<uint8_t>>  &chunkhashes,
+        const sgns::IoDeclaration          &proc,
+        std::vector<char>                  &inputData,
+        std::vector<char>                  &modelFile,
+        const std::vector<sgns::Parameter> *parameters )
+    {
+        (void)proc;
+        std::vector<uint8_t> modelBytes( modelFile.begin(), modelFile.end() );
+        std::string inputText( inputData.begin(), inputData.end() );
+
+        // -----------------------------------------------------------------
+        // Extract generation parameters from JSON parameters array
+        // -----------------------------------------------------------------
+        int   max_tokens   = 512;
+        float temperature  = 0.7f;
+        float top_p        = 0.9f;
+        int   top_k        = 40;
+        int   eos_token_id = 2;
+
+        if ( parameters )
+        {
+            for ( const auto &p : *parameters )
+            {
+                const auto &def = p.get_parameter_default();
+                if ( p.get_name() == "maxTokens" && def.is_number_integer() )
+                    max_tokens = static_cast<int>( def.get<int64_t>() );
+                else if ( p.get_name() == "temperature" && def.is_number() )
+                    temperature = static_cast<float>( def.get<double>() );
+                else if ( p.get_name() == "topP" && def.is_number() )
+                    top_p = static_cast<float>( def.get<double>() );
+                else if ( p.get_name() == "topK" && def.is_number_integer() )
+                    top_k = static_cast<int>( def.get<int64_t>() );
+                else if ( p.get_name() == "eosTokenId" && def.is_number_integer() )
+                    eos_token_id = static_cast<int>( def.get<int64_t>() );
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // Parse input as space-separated token IDs
+        // -----------------------------------------------------------------
+        std::vector<int32_t> token_ids;
+        {
+            std::istringstream stream( inputText );
+            int64_t val;
+            while ( stream >> val )
+                token_ids.push_back( static_cast<int32_t>( val ) );
+        }
+
+        if ( token_ids.empty() )
+        {
+            m_logger->error( "LLM processor: no token IDs in input data" );
+            return ProcessingResult{};
+        }
+
+        m_logger->info( "LLM autoregressive generation: {} input tokens, max_new_tokens={}",
+                        token_ids.size(), max_tokens );
+
+        // -----------------------------------------------------------------
+        // Autoregressive generation loop
+        // -----------------------------------------------------------------
+        std::vector<int32_t> generated;
+        std::vector<uint8_t> subTaskResultHash( SHA256_DIGEST_LENGTH, 0 );
+
+        for ( int step = 0; step < max_tokens; ++step )
+        {
+            int seq_len = static_cast<int>( token_ids.size() );
+            auto logits_tensor = Forward( token_ids, modelBytes, seq_len );
+
+            if ( !logits_tensor || logits_tensor->elementSize() == 0 )
+            {
+                m_logger->error( "LLM forward pass failed at step {}", step );
+                break;
+            }
+
+            const float *logits     = logits_tensor->host<float>();
+            int          vocab_size = logits_tensor->elementSize();
+
+            // For causal LLM with output shape [1, seq_len, vocab_size],
+            // take logits from the last sequence position
+            int dims = logits_tensor->dimensions();
+            if ( dims >= 3 )
+            {
+                int out_seq = logits_tensor->length( 1 );
+                vocab_size  = logits_tensor->length( 2 );
+                logits      = logits + ( out_seq - 1 ) * vocab_size;
+            }
+            else if ( dims == 2 )
+            {
+                // Shape [seq_len, vocab_size] — take last row
+                int out_seq = logits_tensor->length( 0 );
+                vocab_size  = logits_tensor->length( 1 );
+                logits      = logits + ( out_seq - 1 ) * vocab_size;
+            }
+
+            int32_t next_token = SampleToken( logits, vocab_size, temperature, top_p, top_k );
+
+            // Chain hash for proof-of-work
+            auto step_hash = sgprocmanagersha::sha256( logits,
+                                                       static_cast<size_t>( vocab_size ) * sizeof( float ) );
+            chunkhashes.push_back( step_hash );
+
+            std::string combined( subTaskResultHash.begin(), subTaskResultHash.end() );
+            combined.append( step_hash.begin(), step_hash.end() );
+            subTaskResultHash = sgprocmanagersha::sha256( combined.c_str(), combined.size() );
+
+            // Check EOS
+            if ( next_token == eos_token_id )
+            {
+                m_logger->info( "LLM generation: EOS at step {}", step );
+                break;
+            }
+
+            token_ids.push_back( next_token );
+            generated.push_back( next_token );
+
+            m_progress = static_cast<float>( step + 1 ) * 100.0f / static_cast<float>( max_tokens );
+        }
+
+        m_progress = 100.0f;
+        m_logger->info( "LLM generation complete: {} tokens generated", generated.size() );
+
+        // -----------------------------------------------------------------
+        // Build result: generated token IDs as raw int32 bytes
+        // -----------------------------------------------------------------
+        ProcessingResult result;
+        result.hash = subTaskResultHash;
+
+        if ( !generated.empty() )
+        {
+            const size_t byteCount = generated.size() * sizeof( int32_t );
+            std::vector<char> outputBytes( byteCount );
+            std::memcpy( outputBytes.data(), generated.data(), byteCount );
+
+            result.output_buffers =
+                std::make_shared<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>>();
+            result.output_buffers->first.push_back( "" );
+            result.output_buffers->second.push_back( std::move( outputBytes ) );
+        }
+
+        return result;
+    }
+
+    std::unique_ptr<MNN::Tensor> MNN_LLM::Forward(
+        const std::vector<int32_t> &input_ids,
+        std::vector<uint8_t>       &modelFileBytes,
+        int                         seq_len )
+    {
+        auto interpreter = std::unique_ptr<MNN::Interpreter>(
+            MNN::Interpreter::createFromBuffer( modelFileBytes.data(), modelFileBytes.size() ) );
+        if ( !interpreter )
+        {
+            m_logger->error( "LLM: Failed to create MNN interpreter" );
+            return nullptr;
+        }
+
+        MNN::ScheduleConfig config;
+        config.type      = MNN_FORWARD_VULKAN;
+        config.numThread = 4;
+
+        auto session = interpreter->createSession( config );
+        if ( !session )
+        {
+            m_logger->error( "LLM: Failed to create MNN session" );
+            return nullptr;
+        }
+
+        auto inputTensor = interpreter->getSessionInput( session, nullptr );
+        if ( !inputTensor )
+        {
+            m_logger->error( "LLM: Failed to get input tensor" );
+            return nullptr;
+        }
+
+        // Resize input to [1, seq_len]
+        interpreter->resizeTensor( inputTensor, { 1, seq_len } );
+        interpreter->resizeSession( session );
+
+        // Fill input with token IDs
+        MNN::Tensor inputUser( inputTensor, inputTensor->getDimensionType() );
+        auto *ptr = inputUser.host<int32_t>();
+        for ( int i = 0; i < seq_len; ++i )
+            ptr[i] = ( i < static_cast<int>( input_ids.size() ) ) ? input_ids[i] : 0;
+        inputTensor->copyFromHostTensor( &inputUser );
+
+        // Run forward pass
+        interpreter->runSession( session );
+
+        auto outputTensor = interpreter->getSessionOutput( session, nullptr );
+        if ( !outputTensor )
+        {
+            m_logger->error( "LLM: Failed to get output tensor" );
+            return nullptr;
+        }
+
+        auto outputHost = std::make_unique<MNN::Tensor>( outputTensor, outputTensor->getDimensionType() );
+        outputTensor->copyToHostTensor( outputHost.get() );
+        return outputHost;
+    }
+
+    int32_t MNN_LLM::SampleToken( const float *logits, int vocab_size,
+                                    float temperature, float top_p, int top_k ) const
+    {
+        // Build scored pairs: (logit/temperature, token_id)
+        std::vector<std::pair<float, int>> scored( vocab_size );
+        const float temp = std::max( temperature, 0.01f );
+        for ( int i = 0; i < vocab_size; ++i )
+            scored[i] = { logits[i] / temp, i };
+
+        // Top-K: keep only the K highest-scoring tokens
+        int k = std::min( top_k, vocab_size );
+        std::partial_sort( scored.begin(), scored.begin() + k, scored.end(),
+                           []( const auto &a, const auto &b ) { return a.first > b.first; } );
+        scored.resize( k );
+
+        // Softmax over top-K
+        float max_val = scored[0].first;
+        float sum     = 0.0f;
+        for ( auto &s : scored )
+        {
+            s.first = std::exp( s.first - max_val );
+            sum += s.first;
+        }
+        for ( auto &s : scored )
+            s.first /= sum;
+
+        // Top-P (nucleus): keep tokens until cumulative probability >= top_p
+        float cumulative = 0.0f;
+        int   cutoff     = 0;
+        for ( ; cutoff < static_cast<int>( scored.size() ); ++cutoff )
+        {
+            cumulative += scored[cutoff].first;
+            if ( cumulative >= top_p )
+            {
+                ++cutoff;
+                break;
+            }
+        }
+        scored.resize( cutoff );
+
+        // Re-normalize and sample
+        sum = 0.0f;
+        for ( auto &s : scored )
+            sum += s.first;
+
+        static thread_local std::mt19937 rng( std::random_device{}() );
+        std::uniform_real_distribution<float> dist( 0.0f, sum );
+        float r = dist( rng );
+
+        float acc = 0.0f;
+        for ( const auto &s : scored )
+        {
+            acc += s.first;
+            if ( acc >= r )
+                return static_cast<int32_t>( s.second );
+        }
+        return static_cast<int32_t>( scored.back().second );
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new processor types:
- **MNN_LLM** — Autoregressive text generation processor (token-by-token with sampling)
- **MNN_FP4Ultra** — FP4_ULTRA quantized input processor (4-bit NF4 dequantize + inference)

Both are registered in ProcessingManager, validated in CheckProcessValidity(), and wired into the build system.

### MNN_LLM Processor
- Parses input as space-separated token IDs
- Runs MNN forward loop with dynamic sequence length resize per step
- Samples next token using temperature + top-K + top-P nucleus sampling
- Stops on EOS token or max_tokens limit
- Outputs generated token IDs as raw int32 bytes
- Chains SHA256 hashes per generation step for proof-of-work
- Generation parameters (maxTokens, temperature, topP, topK, eosTokenId) read from JSON parameters array

### MNN_FP4Ultra Processor
- Dequantizes packed 4-bit nibbles + per-macroblock float32 scales to FLOAT32
- Uses NF4 symmetric lookup table (same as NeoSwarm FP4Codec)
- Runs windowed MNN inference with overlap-add stitching (same pattern as MNN_Float)
- Data layout: [packed_nibbles: ceil(N/2) bytes][scales: num_macroblocks * sizeof(float)]
- Macroblock size: 64x64 = 4096 elements